### PR TITLE
Lowering Fuzzy search threshold value to match 

### DIFF
--- a/frontend/src/utils/api.ts
+++ b/frontend/src/utils/api.ts
@@ -67,8 +67,6 @@ export async function getIsAdmin(): Promise<boolean> {
     request<{auth: boolean}>("api/isAdmin").then((result) => {
       resolve(result.auth);
     }).catch(() => {
-      resolve(false);
-      return;
       var redirect = `/oauthSignin?redirectOnshapeUri=${encodeURIComponent(window.location.href)}`;
       window.location.href = redirect;
     })

--- a/frontend/src/utils/api.ts
+++ b/frontend/src/utils/api.ts
@@ -67,6 +67,8 @@ export async function getIsAdmin(): Promise<boolean> {
     request<{auth: boolean}>("api/isAdmin").then((result) => {
       resolve(result.auth);
     }).catch(() => {
+      resolve(false);
+      return;
       var redirect = `/oauthSignin?redirectOnshapeUri=${encodeURIComponent(window.location.href)}`;
       window.location.href = redirect;
     })

--- a/frontend/src/utils/fuzzySearch.ts
+++ b/frontend/src/utils/fuzzySearch.ts
@@ -6,6 +6,7 @@ import Fuse from 'fuse.js'
 const options = {
   includeScore: true,
   // keys: ['name']
+  threshold: 0.4,
   keys: ['name', 'insertables.name']
 }
 
@@ -17,6 +18,7 @@ export function search(searchTerm: string, docs: OnshapeDocument[]) {
 
 const insertablesOptions = {
   includeScore: true,
+  threshold: 0.4,
   keys: ['name']
 }
 


### PR DESCRIPTION
Fixes #32 

Lowers threshold value for fuzzy search from 0.6 to 0.4 Makes it so that the results better match the search term.
